### PR TITLE
Bump to Version 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camelot-unchained",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Camelot Unchained Client Library",
   "license": "MPL-2.0",
   "main": "lib/main.js",


### PR DESCRIPTION
Bumped the version to `0.1.6`, this still needs to be published to **npm**