### PR TITLE
Update RestAPI

### DIFF
--- a/definitions/core/CoreSettings.d.ts
+++ b/definitions/core/CoreSettings.d.ts
@@ -7,6 +7,8 @@ import channelId from './constants/channelId';
 declare class CoreSettings {
     cseApiUrl: string;
     cseApiPort: number;
+    publicApiUrl: string;
+    publicApiPort: number;
     hatcheryApiUrl: string;
     hatcheryApiPort: number;
     wyrmlingApiUrl: string;

--- a/definitions/index.d.ts
+++ b/definitions/index.d.ts
@@ -34,4 +34,5 @@ import events from './events/events';
 import stores from './stores/stores';
 import components from './components/components';
 import { postPlotPermissions } from './restapi/RestAPI';
-export { CoreSettings, clientInterface, client, abilityTags, archetype, buildUIMode, channelId, emotes, race, soundEvents, tagConstraintType, gearSlot, plotPermissions, Ability, Combatant, Player, Character, ControlGame, Injury, Population, Inventory, Item, EquippedGear, LogMessage, ChatMessage, ConsoleMessage, core, events, stores, components, postPlotPermissions };
+import * as restAPI from './restapi/RestAPI';
+export { CoreSettings, clientInterface, client, abilityTags, archetype, buildUIMode, channelId, emotes, race, soundEvents, tagConstraintType, gearSlot, plotPermissions, Ability, Combatant, Player, Character, ControlGame, Injury, Population, Inventory, Item, EquippedGear, LogMessage, ChatMessage, ConsoleMessage, core, events, stores, components, postPlotPermissions, restAPI };

--- a/definitions/restapi/RestAPI.d.ts
+++ b/definitions/restapi/RestAPI.d.ts
@@ -3,21 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import 'isomorphic-fetch';
 import { Promise } from 'es6-promise';
-export declare function getJSON(endpoint: string, useHttps?: boolean, query?: any): Promise<any>;
-export declare function postJSON(endpoint: string, useHttps?: boolean, requireAuth?: boolean, data?: any, version?: number): Promise<any>;
-export declare function getFactions(): Promise<any>;
 export declare function getCraftedAbilities(loginToken: string, characterID: string): Promise<any>;
-export declare function getKills(query?: Object): Promise<any>;
-export declare function getScheduledEvents(): Promise<any>;
-export declare function getBanners(): Promise<any>;
-export declare function getPatchNotes(): Promise<any>;
 export declare function getControlGame(includeControlPoints?: boolean): Promise<any>;
-export declare function getAllAttributes(): Promise<any>;
-export declare function getAllBoons(): Promise<any>;
-export declare function getAllBanes(): Promise<any>;
 export declare function getAllPlayers(): Promise<any>;
-export declare function getAllRaces(): Promise<any>;
-export declare function getAllFactions(): Promise<any>;
 export declare function postPlotPermissions(query: Object): Promise<any>;

--- a/definitions/restapi/RestClient.d.ts
+++ b/definitions/restapi/RestClient.d.ts
@@ -1,0 +1,9 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import 'isomorphic-fetch';
+import { Promise } from 'es6-promise';
+export declare function getJSON(endpoint: string, useHttps?: boolean, query?: any): Promise<any>;
+export declare function postJSON(endpoint: string, requireAuth?: boolean, data?: any, version?: number): Promise<any>;

--- a/definitions/restapi/RestClientLegacy.d.ts
+++ b/definitions/restapi/RestClientLegacy.d.ts
@@ -1,0 +1,9 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import 'isomorphic-fetch';
+import { Promise } from 'es6-promise';
+export declare function getJSON(endpoint: string, useHttps?: boolean, query?: any): Promise<any>;
+export declare function postJSON(endpoint: string, useHttps?: boolean, requireAuth?: boolean, data?: any, version?: number): Promise<any>;

--- a/definitions/restapi/RestUtil.d.ts
+++ b/definitions/restapi/RestUtil.d.ts
@@ -1,0 +1,8 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+export declare function checkStatus(response: any): any;
+export declare function parseJSON(response: any): any;
+export declare function makeQueryString(url: string, params?: any): string;

--- a/src/core/CoreSettings.ts
+++ b/src/core/CoreSettings.ts
@@ -13,6 +13,8 @@ const defaults = {
 
   // GAME API - for server info, this will be merged into the single
   // api source in the future.
+  publicApiUrl: 'https://api.camelotunchained.com',
+  publicApiPort: 443,
   hatcheryApiUrl: 'https://hatchery.camelotunchained.com',
   hatcheryApiPort: 8000,
   wyrmlingApiUrl: 'https://wyrmling.camelotunchained.com',
@@ -29,6 +31,8 @@ const defaults = {
 class CoreSettings {
   public cseApiUrl: string = defaults.cseApiUrl;
   public cseApiPort: number = defaults.cseApiPort;
+  public publicApiUrl: string = defaults.hatcheryApiUrl;
+  public publicApiPort: number = defaults.hatcheryApiPort;
   public hatcheryApiUrl: string = defaults.hatcheryApiUrl;
   public hatcheryApiPort: number = defaults.hatcheryApiPort;
   public wyrmlingApiUrl: string = defaults.wyrmlingApiUrl;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import components from './components/components';
 
 // RestAPI
 import {postPlotPermissions} from './restapi/RestAPI';
+import * as restAPI from './restapi/RestAPI';
 
 export {
 
@@ -86,5 +87,6 @@ export {
   components,
 
   // RestAPI
-  postPlotPermissions,
+  postPlotPermissions, // TODO use restAPI below instead
+  restAPI,
 }

--- a/src/restapi/RestAPI.ts
+++ b/src/restapi/RestAPI.ts
@@ -4,173 +4,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import 'isomorphic-fetch';
 import {Promise} from 'es6-promise';
+import * as RestClient from './RestClient';
+import * as RestClientLegacy from './RestClientLegacy';
 
-import CoreSettings from '../core/CoreSettings';
-import channelId from '../core/constants/channelId';
-import client, {hasClientAPI} from '../core/client';
-import events from '../events/events';
-
-// TODO: I wanted this to extend CoreSettings but CoreSettings
-// won't allow super to access its memebers, or pass anything
-// but a default CoreSettings object to its constructor, so
-// you can't customise the settings at all (e.g. like define
-// the api key or current channel)
-class Settings {
-	core: CoreSettings;
-	url: string;
-	port: number;
-	apiKey: string;
-	channelId: channelId;
-	timeout: number;
-	constructor(channel:channelId) {
-		this.core = new CoreSettings();			// TODO: This class is a bit weird
-		this.channelId = channel;
-		this.timeout = 2000;					// default timeout
-		switch(channel) {
-			case channelId.HATCHERY:
-				this.url = 'hatchery.camelotunchained.com';
-				// BUG: (returns https://) this.url = this.core.hatcheryApiUrl;
-				this.port = this.core.hatcheryApiPort;
-				break;
-			case channelId.WYRMLING:
-				this.url = 'wyrmling.camelotunchained.com';
-				// BUG: (returns https://) this.url = this.core.wyrmlingApiUrl;
-				this.port = this.core.wyrmlingApiPort;
-				break;
-		}
-	}
-	getApiKey() {
-		if (!this.apiKey) {
-			this.apiKey = client.loginToken;		// in fake API will prompt for token
-		}
-		return this.apiKey;
-	}
-}
-
-// default to Hatchery
-let settings = new Settings(4);
-if (hasClientAPI()) {
-    events.on('init', () => {
-    settings = new Settings(client.patchResourceChannel);
-  })
-}
-
-function makeAPIUrl(endpoint: string, useHttps: boolean): string {
-  if (endpoint.indexOf('://') != -1) return; // we already have a fully formed url, skip
-  var protocol = useHttps ? 'https' : 'http';
-  var port = useHttps ? '4443' : '8000';
-  return protocol + '://' + settings.url + ':' + port + '/api/' + endpoint;
-}
-
-function checkStatus(response: any) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    let error = new Error(response.statusText);
-    (<any>error).response = response;
-    throw error;
-  }
-}
-
-function parseJSON(response: any) {
-  return response.json();
-}
-
-function makeQueryString(url: string, params: any = {}): string {
-  if (!params) return url;
-  
-  let key: string;
-  let qs: string[] = [];
-  for (key in params) {
-    if (params.hasOwnProperty(key)) {
-      qs.push(key + "=" + encodeURIComponent(params[key]));
-    }
-  }
-  if (qs.length) {
-    url += "?" + qs.join("&");
-  }
-  return url;
-}
-
-export function getJSON(endpoint: string, useHttps: boolean = false, query: any = {}): Promise<any> {
-  return fetch(makeQueryString(makeAPIUrl(endpoint, useHttps), query))
-    .then(checkStatus)
-    .then(parseJSON);
-}
-
-// old API requires loginToken to be in the data object
-export function postJSON(endpoint: string, useHttps: boolean = false, requireAuth: boolean = false, data: any = {}, version: number = 1): Promise<any> {
-  return fetch(makeAPIUrl(endpoint, useHttps), {
-    method: 'post',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'api-version': `${version}`,
-      'loginToken': client.loginToken
-    },
-    body: JSON.stringify(data)
-  })
-  .then(checkStatus)
-  .then(parseJSON);
-}
-
-export function getFactions() {
-  return getJSON('game/factions');
-}
-
+// TODO update this to use new Rest Client
 export function getCraftedAbilities(loginToken: string, characterID: string) {
-  return getJSON('craftedabilities', false, {
-      loginToken: loginToken,
-      characterID: characterID
-    });
+  return RestClientLegacy.getJSON('craftedabilities', false, {
+    loginToken: loginToken,
+    characterID: characterID
+  });
 }
 
-export function getKills(query: Object = {}) {
-  return getJSON('kills', false, query);
-}
-
-export function getScheduledEvents() {
-  return getJSON('scheduledevents');
-}
-
-export function getBanners() {
-  return getJSON('banners');
-}
-
-export function getPatchNotes() {
-  return getJSON('patchnotes');
-}
-
+// TODO update this to use new Rest Client
 export function getControlGame(includeControlPoints: boolean = false) {
-  return getJSON('game/controlgame', false, {includeControlPoints: includeControlPoints});
+  return RestClientLegacy.getJSON('game/controlgame', false, { includeControlPoints: includeControlPoints });
 }
 
-export function getAllAttributes() {
-  return getJSON('game/attributes');
-}
-
-export function getAllBoons() {
-  return getJSON('game/boons');
-}
-
-export function getAllBanes() {
-  return getJSON('game/banes');
-}
-
+// TODO update this to use new Rest Client
 export function getAllPlayers() {
-  return getJSON('game/players');
+  return RestClientLegacy.getJSON('game/players');
 }
 
-export function getAllRaces() {
-  return getJSON('game/races');
-}
-
-export function getAllFactions() {
-  return getJSON('game/factions');
-}
-
+// TODO update this to use new Rest Client
 export function postPlotPermissions(query: Object) {
-  return postJSON('plot/modifypermissions', true, false, query);
+  return RestClientLegacy.postJSON('plot/modifypermissions', true, false, query);
 }

--- a/src/restapi/RestClient.ts
+++ b/src/restapi/RestClient.ts
@@ -1,0 +1,84 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import 'isomorphic-fetch';
+import {Promise} from 'es6-promise';
+
+import CoreSettings from '../core/CoreSettings';
+import channelId from '../core/constants/channelId';
+import client, {hasClientAPI} from '../core/client';
+import events from '../events/events';
+import * as RestUtil from './RestUtil';
+
+class Settings {
+  core: CoreSettings;
+  url: string;
+  port: number;
+  channelId: channelId;
+  apiToken: string;
+  timeout: number;
+  constructor(channel: channelId) {
+    this.core = new CoreSettings();
+    this.timeout = 2000;
+    if (hasClientAPI()) {
+      events.on('init', () => {
+        this.apiToken = client.loginToken;
+        this.channelId = client.patchResourceChannel;
+        this.determineApiDetails();
+      })
+    }
+  }
+  private determineApiDetails() {
+    // TODO remove this when there are channel based API's
+    this.url = this.core.publicApiUrl;
+    this.port = this.core.publicApiPort;
+    // TODO enable below when there are channel based API's
+    // switch (this.channelId) {
+    //   case channelId.HATCHERY:
+    //     this.url = this.core.hatcheryApiUrl;
+    //     this.port = this.core.hatcheryApiPort;
+    //     break;
+    //   case channelId.WYRMLING:
+    //     this.url = this.core.wyrmlingApiUrl;
+    //     this.port = this.core.wyrmlingApiPort;
+    //     break;
+    // }
+  }
+}
+
+// default to Hatchery
+const settings = new Settings(4);
+
+function makeAPIUrl(endpoint: string): string {
+  if (endpoint.indexOf('://') != -1) return; // we already have a fully formed url, skip
+  let url = settings.url;
+  // only add port if it is required
+  if ((url.indexOf('https://') === 0 && settings.port !== 443) || (url.indexOf('http://') === 0 && settings.port !== 80)) {
+    url = url + ':' + settings.port;
+  }
+  return url + '/' + endpoint.replace(/^\//g, '');
+}
+
+export function getJSON(endpoint: string, useHttps: boolean = false, query: any = {}): Promise<any> {
+  return fetch(RestUtil.makeQueryString(makeAPIUrl(endpoint), query))
+    .then(RestUtil.checkStatus)
+    .then(RestUtil.parseJSON);
+}
+
+export function postJSON(endpoint: string, requireAuth: boolean = false, data: any = {}, version: number = 1): Promise<any> {
+  return fetch(makeAPIUrl(endpoint), {
+    method: 'post',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'api-version': `${version}`,
+      'loginToken': client.loginToken
+    },
+    body: JSON.stringify(data)
+  })
+    .then(RestUtil.checkStatus)
+    .then(RestUtil.parseJSON);
+}

--- a/src/restapi/RestClientLegacy.ts
+++ b/src/restapi/RestClientLegacy.ts
@@ -1,0 +1,90 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import 'isomorphic-fetch';
+import {Promise} from 'es6-promise';
+
+import CoreSettings from '../core/CoreSettings';
+import channelId from '../core/constants/channelId';
+import client, {hasClientAPI} from '../core/client';
+import events from '../events/events';
+import * as RestUtil from './RestUtil';
+
+// TODO remove this when the API's are updated
+
+// TODO: I wanted this to extend CoreSettings but CoreSettings
+// won't allow super to access its memebers, or pass anything
+// but a default CoreSettings object to its constructor, so
+// you can't customise the settings at all (e.g. like define
+// the api key or current channel)
+class Settings {
+  core: CoreSettings;
+  url: string;
+  port: number;
+  apiKey: string;
+  channelId: channelId;
+  timeout: number;
+  constructor(channel: channelId) {
+    this.core = new CoreSettings();			// TODO: This class is a bit weird
+    this.channelId = channel;
+    this.timeout = 2000;					// default timeout
+    switch (channel) {
+      case channelId.HATCHERY:
+        this.url = 'hatchery.camelotunchained.com';
+        // BUG: (returns https://) this.url = this.core.hatcheryApiUrl;
+        this.port = this.core.hatcheryApiPort;
+        break;
+      case channelId.WYRMLING:
+        this.url = 'wyrmling.camelotunchained.com';
+        // BUG: (returns https://) this.url = this.core.wyrmlingApiUrl;
+        this.port = this.core.wyrmlingApiPort;
+        break;
+    }
+  }
+  getApiKey() {
+    if (!this.apiKey) {
+      this.apiKey = client.loginToken;		// in fake API will prompt for token
+    }
+    return this.apiKey;
+  }
+}
+
+// default to Hatchery
+let settings = new Settings(4);
+if (hasClientAPI()) {
+  events.on('init', () => {
+    settings = new Settings(client.patchResourceChannel);
+  })
+}
+
+function makeAPIUrl(endpoint: string, useHttps: boolean): string {
+  if (endpoint.indexOf('://') != -1) return; // we already have a fully formed url, skip
+  var protocol = useHttps ? 'https' : 'http';
+  var port = useHttps ? '4443' : '8000';
+  return protocol + '://' + settings.url + ':' + port + '/api/' + endpoint;
+}
+
+export function getJSON(endpoint: string, useHttps: boolean = false, query: any = {}): Promise<any> {
+  return fetch(RestUtil.makeQueryString(makeAPIUrl(endpoint, useHttps), query))
+    .then(RestUtil.checkStatus)
+    .then(RestUtil.parseJSON);
+}
+
+// old API requires loginToken to be in the data object
+export function postJSON(endpoint: string, useHttps: boolean = false, requireAuth: boolean = false, data: any = {}, version: number = 1): Promise<any> {
+  return fetch(makeAPIUrl(endpoint, useHttps), {
+    method: 'post',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'api-version': `${version}`,
+      'loginToken': client.loginToken
+    },
+    body: JSON.stringify(data)
+  })
+    .then(RestUtil.checkStatus)
+    .then(RestUtil.parseJSON);
+}

--- a/src/restapi/RestUtil.ts
+++ b/src/restapi/RestUtil.ts
@@ -1,0 +1,35 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export function checkStatus(response: any) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    let error = new Error(response.statusText);
+    (<any>error).response = response;
+    throw error;
+  }
+}
+
+export function parseJSON(response: any) {
+  return response.json();
+}
+
+export function makeQueryString(url: string, params: any = {}): string {
+  if (!params) return url;
+
+  let key: string;
+  let qs: string[] = [];
+  for (key in params) {
+    if (params.hasOwnProperty(key)) {
+      qs.push(key + "=" + encodeURIComponent(params[key]));
+    }
+  }
+  if (qs.length) {
+    url += "?" + qs.join("&");
+  }
+  return url;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "buildOnSave": false,
     "filesGlob": [
         "./src/**/*.ts",
-        "./src/**/*.tsx"
+        "./src/**/*.tsx",
+        "./typings/**/*.ts"
     ],
     "exclude": [
       "typings/browser.d.ts",


### PR DESCRIPTION
Updated the `RestAPI` to handle the new API https://api.camelotunchained.com/

Moved old API methods (ones in use) to a Legacy Rest Client, which interacts with the existing API structure.

Ideally the new RestClient will be updated to handle different api hosts (hatchery & wymling)

Will add methods from https://api.camelotunchained.com/ in a separate PR, if this change is ok.

Have also exported all RestAPI methods as a `restAPI` variable (not sure if this is ideal).

I did notice that a test build on module in cu-ui failed on `Cannot find module 'es6-promise'.` which required running `typings install es6-promise --save` so that is potentially something which will need updating.