### PR TITLE
Improve Rest API requests to reduce preflight requests

### DIFF
--- a/definitions/restapi/RestClient.d.ts
+++ b/definitions/restapi/RestClient.d.ts
@@ -7,4 +7,4 @@ import 'isomorphic-fetch';
 import { Promise } from 'es6-promise';
 export declare function getJSON(endpoint: string, requireAuth?: boolean, query?: any, version?: number): Promise<any>;
 export declare function deleteJSON(endpoint: string, requireAuth?: boolean, query?: any, version?: number): Promise<any>;
-export declare function postJSON(endpoint: string, requireAuth?: boolean, data?: any, version?: number): Promise<any>;
+export declare function postJSON(endpoint: string, requireAuth?: boolean, data?: any, query?: any, version?: number): Promise<any>;

--- a/src/restapi/RestClient.ts
+++ b/src/restapi/RestClient.ts
@@ -62,20 +62,22 @@ function makeAPIUrl(endpoint: string): string {
   return url + '/' + endpoint.replace(/^\//g, '');
 }
 
-function makeDefaultHeaders(requireAuth: boolean, version: number = 1): any {
-  const headers: any = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    'api-version': `${version}`
-  };
-  if (requireAuth) {
-    headers.loginToken = settings.apiToken
+function addDefaultHeaders(headers: any, requireAuth: boolean, version: number = 1): any {
+  if (headers.hasOwnProperty('Accept') === false) {
+    headers['accept'] = `application/json;version=${version}`;
   }
-  return headers;
+}
+
+function addDefaultQueryParameters(query: any, requireAuth: boolean): any {
+  if (requireAuth && query.hasOwnProperty('loginToken') === false) {
+    query.loginToken = settings.apiToken;
+  }
 }
 
 export function getJSON(endpoint: string, requireAuth: boolean = false, query: any = {}, version: number = 1): Promise<any> {
-  const headers = makeDefaultHeaders(requireAuth, version);
+  const headers = {};
+  addDefaultHeaders(headers, requireAuth, version);
+  addDefaultQueryParameters(query, requireAuth);
   return fetch(RestUtil.makeQueryString(makeAPIUrl(endpoint), query), {
     method: 'get',
     headers: headers
@@ -85,7 +87,9 @@ export function getJSON(endpoint: string, requireAuth: boolean = false, query: a
 }
 
 export function deleteJSON(endpoint: string, requireAuth: boolean = false, query: any = {}, version: number = 1): Promise<any> {
-  const headers = makeDefaultHeaders(requireAuth, version);
+  const headers = {};
+  addDefaultHeaders(headers, requireAuth, version);
+  addDefaultQueryParameters(query, requireAuth);
   return fetch(RestUtil.makeQueryString(makeAPIUrl(endpoint), query), {
     method: 'delete',
     headers: headers
@@ -94,9 +98,13 @@ export function deleteJSON(endpoint: string, requireAuth: boolean = false, query
     .then(RestUtil.parseJSON);
 }
 
-export function postJSON(endpoint: string, requireAuth: boolean = false, data: any = {}, version: number = 1): Promise<any> {
-  const headers = makeDefaultHeaders(requireAuth, version);
-  return fetch(makeAPIUrl(endpoint), {
+export function postJSON(endpoint: string, requireAuth: boolean = false, data: any = {}, query: any = {}, version: number = 1): Promise<any> {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  addDefaultHeaders(headers, requireAuth, version);
+  addDefaultQueryParameters(query, requireAuth);
+  return fetch(RestUtil.makeQueryString(makeAPIUrl(endpoint), query), {
     method: 'post',
     headers: headers,
     body: JSON.stringify(data)


### PR DESCRIPTION
Improve Rest API requests to reduce preflight requests

- changed default headers
- moved `loginToken` to query string instead of header

`GET` requests now trigger no `OPTIONS` preflight

`POST` requests still trigger `OPTIONS` preflight due to `Content-Type` header

This is related to Issue #18