### PR TITLE
Compile using LF line endings.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "sourceMap": false,
         "jsx": "react",
         "module": "commonjs",
-        "declaration": true
+        "declaration": true,
+        "newLine": "LF"
     },
     "formatCodeOptions": {
         "indentSize": 2,


### PR DESCRIPTION
Do this because we store the definitions output by the compiler in the repo with LF line endings (see .gitattributes) and we don't want git to think they are modified each time we compile.